### PR TITLE
Fix password hash behaviour

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,8 @@ Role Variables
 ### Mandatory
 
  * `users_root_password` (string):
-   Root password to be set for the system.
+   Root password to be set for the system. The password is expected to be hashed
+   (with [`ansible.builtin.password_hash`][ansible:filter:password_hash]).
 
  * `users_customer_group` (string):
    Name of the system group to which all customer user accounts are added.
@@ -119,3 +120,4 @@ Role Variables
 
 
 [ansible:vars:default_jinja2_native]: https://docs.ansible.com/ansible/latest/reference_appendices/config.html#default-jinja2-native
+[ansible:filter:password_hash]: https://docs.ansible.com/ansible/latest/collections/ansible/builtin/password_hash_filter.html

--- a/README.md
+++ b/README.md
@@ -38,14 +38,24 @@ Role Variables
 ### Mandatory
 
  * `users_root_password` (string):
-   Root password to be set for the system. The password is expected to be hashed
-   (with [`ansible.builtin.password_hash`][ansible:filter:password_hash]).
+   Root password to be set for the system. The password is expected to be in
+   clear-text, unless `users_root_password_is_hashed` is set to `yes`, in which
+   case it is expected to be the hashed (with
+   [`ansible.builtin.password_hash`][ansible:filter:password_hash]).
+
+ * `users_root_password_salt` (string):
+   Salt to be used for hashing the root password (not required if
+   `users_root_password_is_hashed` is set to `yes`).
 
  * `users_customer_group` (string):
    Name of the system group to which all customer user accounts are added.
    **Note**: Only required if `users_customer` (see below) is non-empty.
 
 ### Optional
+
+ * `users_root_password_is_hashed` (boolean, default: `no`):
+   If set to `yes`, `users_root_password` is assumed to have been hashed
+   already (in this case, `users_root_password_salt` is not required).
 
  * `users_root_authorized_keys` (list, default: `[]`):
    SSH public keys that will be given authorisation to log in as `root`.

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,5 +1,6 @@
 ---
 
+users_root_password_is_hashed: no
 users_root_authorized_keys: []
 
 users_adfinis: []

--- a/tasks/root.yml
+++ b/tasks/root.yml
@@ -3,7 +3,14 @@
 - name: Set root user password
   ansible.builtin.user:
     name: root
-    password: '{{ users_root_password }}'
+    password: "{{ users_root_password | ansible.builtin.password_hash('sha512', users_root_password_salt) }}"
+  when: not users_root_password_is_hashed
+
+- name: Set pre-hashed root user password
+  ansible.builtin.user:
+    name: root
+    password: "{{ users_root_password }}"
+  when: users_root_password_is_hashed
 
 - name: Create ssh directory for root
   ansible.builtin.file:


### PR DESCRIPTION
`users_root_password` was previously assumed to be hashed (with the [`ansible.builtin.password_hash` filter](https://docs.ansible.com/ansible/latest/collections/ansible/builtin/password_hash_filter.html)), but that was not stated anywhere in the documentation.

The first commit fixes the documentation to mention that (to be backported to the 0.1 branch).

Nevertheless, the behaviour is rather unintuitive, and IMHO a bad default. Consequently, we now switch to letting the role handle the hashing (i.e. the password should now be passed in clear-text, together with a new mandatory variable `users_root_password_salt`). To get back the old behaviour, we add the boolean `users_root_password_is_hashed` (default: false), which will cause the role not to hash it again.

This is implemented in the second commit (to be in the next release, i.e. presumably 0.2).