### PR TITLE
chore: release v0.4.0

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,4 +1,4 @@
-(unreleased)
+v0.4.0 (released: 2025-11-12)
 
 BREAKING CHANGES:
 


### PR DESCRIPTION
The most notable change is #21 (**BREAKING CHANGE**, requires setting some additional variables now, otherwise this role will stop doing anything, see the changelog).

Apart from that, it contains some chore changes (mostly related to CI/release/documentation).

Based on the support policy, this also makes the v0.3 branch obsolete and unsupported. I'll keep the branch around for now, though, to avoid breaking any consumers that simply pull `v0.3`.