### PR TITLE
fix: remove not needed condition

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -33,7 +33,6 @@
     - "role::users:customer"
   when:
     - users_configure_customers
-    - users_customer
 
 - name: Delete initial/default user
   ansible.builtin.import_tasks: default.yml


### PR DESCRIPTION
Since the update to Ansible 2.20.1, this role fails because it requires the users_customer condition to be a boolean rather than a list. Since the customers group should be created whenever the users_configure_customers variable is set to true, this additional condition is not needed.